### PR TITLE
Multiple thread-local loggers, including tee files. Plugin configuration request.

### DIFF
--- a/dqcsim-api/src/external/scfg.rs
+++ b/dqcsim-api/src/external/scfg.rs
@@ -1,5 +1,8 @@
 use super::*;
-use dqcsim::common::{log, log::tee_file::TeeFile};
+use dqcsim::common::{
+    log,
+    log::{callback::LogCallback, tee_file::TeeFile},
+};
 use std::time::*;
 
 /// Constructs an empty simulation configuration.

--- a/dqcsim-plugin/src/main.rs
+++ b/dqcsim-plugin/src/main.rs
@@ -1,19 +1,19 @@
 use dqcsim::{
-    common::{ipc::connection::Connection, log::LoglevelFilter, protocol::Response},
+    common::{ipc::connection::Connection, protocol::Response},
     debug,
     host::configuration::PluginType,
     info,
 };
 use failure::Error;
 use ipc_channel::ipc::IpcSelectionResult;
-use std::{env, str::FromStr};
+use std::env;
 
 fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().collect();
 
+    // Keeping this to defer type
     let name: &str = args[1].as_ref();
     let server = args[2].as_ref();
-    let level = LoglevelFilter::from_str(&args[3]).unwrap();
 
     let plugin_type = if name.starts_with("front") {
         PluginType::Frontend
@@ -23,7 +23,7 @@ fn main() -> Result<(), Error> {
         PluginType::Operator
     };
 
-    let mut connection = Connection::init(name, level, server, plugin_type)?;
+    let mut connection = Connection::init(server, plugin_type)?;
 
     eprintln!("stderr");
     println!("stdout");

--- a/dqcsim/src/common/ipc/plugin.rs
+++ b/dqcsim/src/common/ipc/plugin.rs
@@ -43,7 +43,10 @@ pub fn connect_simulator(
     let (simulator, plugin) = channel()?;
     connect.send(simulator)?;
     match plugin.request.recv() {
-        Ok(Request::Configuration(configuration)) => Ok((plugin, *configuration)),
+        Ok(Request::Configuration(configuration)) => {
+            plugin.response.send(Response::Success)?;
+            Ok((plugin, *configuration))
+        }
         _ => Err(ErrorKind::Other("Handshake problem".to_string()))?,
     }
 }

--- a/dqcsim/src/common/ipc/plugin.rs
+++ b/dqcsim/src/common/ipc/plugin.rs
@@ -4,7 +4,7 @@ use crate::{
         ipc::{DownstreamChannel, PluginChannel, SimulatorChannel, UpstreamChannel},
         protocol::{InitializeResponse, Request, Response},
     },
-    host::configuration::PluginType,
+    host::configuration::{PluginConfiguration, PluginType},
 };
 
 use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
@@ -35,12 +35,17 @@ fn channel() -> Result<(SimulatorChannel, PluginChannel)> {
 ///
 /// [`Plugin`]: ../plugin/struct.Plugin.html
 /// [`Simulation`]: ../simulator/struct.Simulation.html
-pub fn connect_simulator(server: impl Into<String>) -> Result<PluginChannel> {
+pub fn connect_simulator(
+    server: impl Into<String>,
+) -> Result<(PluginChannel, PluginConfiguration)> {
     // Attempt to connect to the server
     let connect = IpcSender::connect(server.into())?;
     let (simulator, plugin) = channel()?;
     connect.send(simulator)?;
-    Ok(plugin)
+    match plugin.request.recv() {
+        Ok(Request::Configuration(configuration)) => Ok((plugin, *configuration)),
+        _ => Err(ErrorKind::Other("Handshake problem".to_string()))?,
+    }
 }
 
 /// Connect an upstream [`Plugin`] instance to a downstream [`Plugin`] instance.
@@ -105,26 +110,4 @@ pub fn initialize(
         }
         _ => Err(ErrorKind::Other("Handshake problem".to_string()))?,
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::connect_simulator as connect_simulator_;
-    use crate::common::ipc::SimulatorChannel;
-    use ipc_channel::ipc::IpcOneShotServer;
-
-    #[test]
-    fn connect_simulator() {
-        let (server, server_name): (IpcOneShotServer<SimulatorChannel>, _) =
-            IpcOneShotServer::new().unwrap();
-
-        let plugin = std::thread::spawn(move || {
-            let connect = connect_simulator_(server_name);
-            assert!(connect.is_ok());
-        });
-
-        assert!(server.accept().is_ok());
-        assert!(plugin.join().is_ok());
-    }
-
 }

--- a/dqcsim/src/common/ipc/simulator.rs
+++ b/dqcsim/src/common/ipc/simulator.rs
@@ -2,7 +2,6 @@ use crate::{
     common::{
         error::{err, Result},
         ipc::SimulatorChannel,
-        log::LoglevelFilter,
     },
     trace,
 };
@@ -26,7 +25,6 @@ use std::{
 /// [`SimulatorChannel`]: ../struct.SimulatorChannel.html
 pub fn start(
     command: &mut Command,
-    level: LoglevelFilter,
     accept_timeout: impl Into<Option<Duration>>,
     stderr_mode: impl Into<Stdio>,
     stdout_mode: impl Into<Stdio>,
@@ -37,7 +35,6 @@ pub fn start(
     // Spawn child process
     let child = command
         .arg(server_name)
-        .arg(level.to_string())
         .stderr(stderr_mode.into())
         .stdout(stdout_mode.into())
         .spawn()?;
@@ -93,7 +90,7 @@ pub fn start(
 #[cfg(test)]
 mod tests {
     use super::start;
-    use crate::{common::log::LoglevelFilter, host::configuration::StreamCaptureMode};
+    use crate::host::configuration::StreamCaptureMode;
     use std::{process::Command, time::Duration};
 
     #[test]
@@ -101,7 +98,6 @@ mod tests {
         let command = "/bin/sh";
         let timeout = start(
             Command::new(command).arg("sleep").arg("1"),
-            LoglevelFilter::Off,
             Duration::from_nanos(1u64),
             StreamCaptureMode::Null,
             StreamCaptureMode::Null,

--- a/dqcsim/src/common/log/callback.rs
+++ b/dqcsim/src/common/log/callback.rs
@@ -1,0 +1,38 @@
+use crate::common::log::{Log, Loglevel, LoglevelFilter, Record};
+
+/// Log callback function structure.
+///
+/// Note the lack of derives; they don't play well with `Box<dyn Fn...>`...
+/// I wonder why. That's primarily why this struct is defined outside
+/// `SimulatorConfiguration`.
+pub struct LogCallback {
+    /// The callback function to call.
+    ///
+    /// The sole argument is the log message record.
+    pub callback: Box<dyn Fn(&Record) + Send>,
+
+    /// Verbosity level for calling the log callback function.
+    pub filter: LoglevelFilter,
+}
+
+impl Log for LogCallback {
+    fn name(&self) -> &str {
+        "?"
+    }
+    fn enabled(&self, level: Loglevel) -> bool {
+        LoglevelFilter::from(level) <= self.filter
+    }
+    fn log(&self, record: &Record) {
+        (self.callback)(record);
+    }
+}
+
+impl std::fmt::Debug for LogCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "LogCallback {{ callback: <...>, filter: {:?} }}",
+            self.filter
+        )
+    }
+}

--- a/dqcsim/src/common/log/mod.rs
+++ b/dqcsim/src/common/log/mod.rs
@@ -34,6 +34,12 @@
 //! smaller or equal than the configured [`LoglevelFilter`] of the
 //! [`LogProxy`].
 //!
+//! ## TeeFile
+//!
+//! A [`TeeFile`] forwards log [`Records`] to a file. It logs records with it's
+//! logger name if the generated log [`Record`] [`Loglevel`] is smaller or
+//! equal than the configured [`LoglevelFilter`] of the [`TeeFile`].
+//!
 //! # Basic Example
 //!
 //! ```rust
@@ -51,6 +57,7 @@
 //!     LoglevelFilter::Note,
 //!     LoglevelFilter::Debug,
 //!     None,
+//!     vec![]
 //! )
 //! .unwrap();
 //!
@@ -64,7 +71,7 @@
 //!
 //!     // Initialize the thread-local logger to enable forwarding of log records to
 //!     // the log thread.
-//!     init(log_proxy);
+//!     init(vec![log_proxy]);
 //!
 //!     // Generate a log record
 //!     note!("Note from thread via proxy");
@@ -84,6 +91,7 @@
 //! [`LogThread`]: ./thread/struct.LogThread.html
 //! [`spawn`]: ./thread/struct.LogThread.html#method.spawn
 //! [`LogProxy`]: ./proxy/struct.LogProxy.html
+//! [`TeeFile`]: ./tee_file/struct.TeeFile.html
 //! [`Record`]: ./struct.Record.html
 //! [`Records`]: ./struct.Record.html
 //! [`Loglevel`]: ./enum.Loglevel.html
@@ -98,6 +106,7 @@
 #[doc(hidden)]
 pub use ref_thread_local as _ref_thread_local;
 
+pub mod callback;
 pub mod channel;
 pub mod proxy;
 pub mod router;
@@ -137,7 +146,7 @@ use std::{cell::RefCell, fmt};
 ///         true
 ///     }
 ///
-///     fn log(&self, record: Record) {
+///     fn log(&self, record: &Record) {
 ///         // The SimpleLogger logs to Standard Output.
 ///         println!("{}", record);
 ///     }
@@ -149,12 +158,12 @@ pub trait Log {
     /// Returns true if the provided loglevel is enabled
     fn enabled(&self, level: Loglevel) -> bool;
     /// Log the incoming record
-    fn log(&self, record: Record);
+    fn log(&self, record: &Record);
 }
 
 thread_local! {
-    /// The thread-local logger.
-    pub static LOGGER: RefCell<Option<Box<dyn Log>>> = RefCell::new(None);
+    /// The thread-local loggers.
+    pub static LOGGERS: RefCell<Option<Vec<Box<dyn Log>>>> = RefCell::new(None);
 }
 
 lazy_static! {
@@ -369,27 +378,50 @@ impl Record {
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            humantime::format_rfc3339_seconds(self.metadata.timestamp)
+        )?;
+        write!(
+            f,
+            "{:<6}",
+            format!(
+                "+{}ms",
+                self.metadata.timestamp.elapsed().unwrap().as_millis()
+            )
+        )?;
+        write!(f, "{:>5} ", format!("{}", self.metadata.level))?;
+        write!(
+            f,
+            "{:<32} ",
+            format!(
+                "{:>5}:{:<2} {} ",
+                self.metadata.process, self.metadata.thread, self.logger,
+            )
+        )?;
         write!(f, "{}", self.payload)
     }
 }
 
-/// Update the thread-local logger.
-fn update(log: Option<Box<dyn Log>>) -> error::Result<()> {
-    LOGGER.with(|logger| {
-        let mut logger = logger.try_borrow_mut().context(ErrorKind::LogError(
-            "failed to update thread-local log level".to_string(),
+/// Update the thread-local loggers.
+fn update(loggers: Option<Vec<Box<dyn Log>>>) -> error::Result<()> {
+    LOGGERS.with(|x| {
+        let mut x = x.try_borrow_mut().context(ErrorKind::LogError(
+            "Unable to update thread-local loggers".to_string(),
         ))?;
-        *logger = log;
+        *x = loggers;
         Ok(())
     })
 }
 
-/// Initialize the thread-local logger.
-pub fn init(log: Box<dyn Log>) -> error::Result<()> {
-    update(Some(log))
+/// Initialize the thread-local loggers.
+pub fn init(loggers: Vec<Box<dyn Log>>) -> error::Result<()> {
+    eprintln!("Updated the loggers to {:?}", &loggers.len());
+    update(Some(loggers))
 }
 
-/// Deinitialize the thread-local logger.
+/// Deinitialize the thread-local loggers.
 pub fn deinit() -> error::Result<()> {
     update(None)
 }
@@ -398,20 +430,22 @@ pub fn deinit() -> error::Result<()> {
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         use $crate::common::log::_ref_thread_local::RefThreadLocal;
-        $crate::common::log::LOGGER.with(|logger| {
-            if let Some(ref logger) = *logger.borrow() {
-                if logger.enabled($lvl) {
-                    logger.log($crate::common::log::Record::new(
-                        logger.name(),
-                        format!($($arg)+),
-                        $lvl,
-                        $target,
-                        file!(),
-                        line!(),
-                        *$crate::common::log::PID,
-                        *$crate::common::log::TID.borrow()
-                    ));
-                }
+        $crate::common::log::LOGGERS.with(|loggers| {
+            if let Some(ref loggers) = *loggers.borrow() {
+                loggers.iter().for_each(|logger| {
+                    if logger.enabled($lvl) {
+                        logger.log(&$crate::common::log::Record::new(
+                            logger.name(),
+                            format!($($arg)+),
+                            $lvl,
+                            $target,
+                            file!(),
+                            line!(),
+                            *$crate::common::log::PID,
+                            *$crate::common::log::TID.borrow()
+                        ));
+                    }
+                })
             }
         });
     });

--- a/dqcsim/src/common/log/mod.rs
+++ b/dqcsim/src/common/log/mod.rs
@@ -417,7 +417,6 @@ fn update(loggers: Option<Vec<Box<dyn Log>>>) -> error::Result<()> {
 
 /// Initialize the thread-local loggers.
 pub fn init(loggers: Vec<Box<dyn Log>>) -> error::Result<()> {
-    eprintln!("Updated the loggers to {:?}", &loggers.len());
     update(Some(loggers))
 }
 

--- a/dqcsim/src/common/log/proxy.rs
+++ b/dqcsim/src/common/log/proxy.rs
@@ -45,9 +45,9 @@ impl<T: Sender<Item = Record>> Log for LogProxy<T> {
     fn enabled(&self, level: Loglevel) -> bool {
         LoglevelFilter::from(level) <= self.level
     }
-    fn log(&self, record: Record) {
+    fn log(&self, record: &Record) {
         self.sender
-            .send(record)
+            .send(record.clone())
             .expect("LogProxy failed to send record");
     }
 }
@@ -63,6 +63,7 @@ mod tests {
             LoglevelFilter::Off,
             LoglevelFilter::Trace,
             None,
+            vec![],
         )
         .unwrap();
 

--- a/dqcsim/src/common/log/router.rs
+++ b/dqcsim/src/common/log/router.rs
@@ -16,7 +16,8 @@ pub fn route(
 ) {
     let name = name.into();
     std::thread::spawn(move || {
-        init(LogProxy::boxed(name, level, sender.clone())).expect("Log channel forwarding failed");
+        init(vec![LogProxy::boxed(name, level, sender.clone())])
+            .expect("Log channel forwarding failed");
         while let Ok(record) = receiver.recv() {
             sender.send(record).expect("Log channel forwarding failed");
         }

--- a/dqcsim/src/common/log/stdio.rs
+++ b/dqcsim/src/common/log/stdio.rs
@@ -25,7 +25,12 @@ pub fn proxy_stdio(
 ) -> JoinHandle<()> {
     let name = name.into();
     spawn(move || {
-        init(LogProxy::boxed(name, LoglevelFilter::from(level), sender)).unwrap();
+        init(vec![LogProxy::boxed(
+            name,
+            LoglevelFilter::from(level),
+            sender,
+        )])
+        .unwrap();
         let mut buf = Vec::new();
         let mut byte = [0u8];
         loop {

--- a/dqcsim/src/common/protocol/mod.rs
+++ b/dqcsim/src/common/protocol/mod.rs
@@ -1,6 +1,6 @@
 //! Defines the protocols for all forms of communication.
 
-use crate::common::log::LoglevelFilter;
+use crate::{common::log::LoglevelFilter, host::configuration::PluginConfiguration};
 use serde::{Deserialize, Serialize};
 
 mod arb_cmd;
@@ -12,6 +12,8 @@ pub use arb_data::ArbData;
 /// Simulator to plugin requests.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Request {
+    /// Handshake the configuration for reference.
+    Configuration(Box<PluginConfiguration>),
     /// Request to initialize the plugin.
     ///
     /// When requested, the plugin should connect to provided downstream and

--- a/dqcsim/src/host/configuration/mod.rs
+++ b/dqcsim/src/host/configuration/mod.rs
@@ -19,4 +19,4 @@ pub use plugin::{
 };
 
 mod simulator;
-pub use simulator::{LogCallback, SimulatorConfiguration};
+pub use simulator::SimulatorConfiguration;

--- a/dqcsim/src/host/configuration/simulator.rs
+++ b/dqcsim/src/host/configuration/simulator.rs
@@ -1,33 +1,8 @@
 use crate::{
-    common::log::{tee_file::TeeFile, LoglevelFilter, Record},
+    common::log::{callback::LogCallback, tee_file::TeeFile, LoglevelFilter},
     host::configuration::{PluginConfiguration, Seed},
 };
 use serde::{Deserialize, Serialize};
-
-/// Log callback function structure.
-///
-/// Note the lack of derives; they don't play well with `Box<dyn Fn...>`...
-/// I wonder why. That's primarily why this struct is defined outside
-/// `SimulatorConfiguration`.
-pub struct LogCallback {
-    /// The callback function to call.
-    ///
-    /// The sole argument is the log message record.
-    pub callback: Box<dyn Fn(&Record) + Send>,
-
-    /// Verbosity level for calling the log callback function.
-    pub filter: LoglevelFilter,
-}
-
-impl std::fmt::Debug for LogCallback {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "LogCallback {{ callback: <...>, filter: {:?} }}",
-            self.filter
-        )
-    }
-}
 
 /// The complete configuration for a DQCsim run.
 #[derive(Debug, Deserialize, Serialize)]

--- a/dqcsim/src/host/plugin/process.rs
+++ b/dqcsim/src/host/plugin/process.rs
@@ -31,11 +31,15 @@ impl PluginProcess {
 
         let (mut child, mut channel) = start(
             command,
-            configuration.nonfunctional.verbosity,
             &configuration.nonfunctional.accept_timeout,
             &configuration.nonfunctional.stderr_mode,
             &configuration.nonfunctional.stdout_mode,
         )?;
+
+        // Handshake
+        channel
+            .request
+            .send(Request::Configuration(Box::new(configuration.clone())))?;
 
         route(
             configuration.name.as_str(),

--- a/dqcsim/src/host/simulator.rs
+++ b/dqcsim/src/host/simulator.rs
@@ -86,6 +86,7 @@ impl Simulator {
             configuration.dqcsim_level,
             configuration.stderr_level,
             configuration.log_callback,
+            configuration.tee_files,
         )?;
 
         trace!("Constructing Simulator");


### PR DESCRIPTION
This pull request modifies the following;

Log module:
- the log module now supports multiple thread-local loggers (init function now takes `Vec<Box<dyn Log>>`)
- `LogCallback` moved to log module, also implements the `Log` trait now
- implement `Log` trait for `TeeFile`

Plugin process:
- ` PluginProcess::new` sends the plugin configuration after request/response channel setup. Plugins should response with `Response::Success`.
