### PR TITLE
Prevent LogThread panic if stderr can't be wrapped

### DIFF
--- a/rust/src/core/common/log/thread.rs
+++ b/rust/src/core/common/log/thread.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     common::{
-        error::{err, oe_log_err, Result},
+        error::{err, Result},
         log::{
             callback::LogCallback,
             deinit, init,
@@ -48,7 +48,8 @@ impl LogThread {
         // Spawn the local channel log thread.
         let handler = thread::spawn(move || {
             let mut t = if stderr_level > LoglevelFilter::Off {
-                Some(stderr().ok_or_else(oe_log_err("Failed to acquire stderr"))?)
+                // This may return None which results in no logging to stderr
+                stderr()
             } else {
                 None
             };


### PR DESCRIPTION
This modifies the behaviour of the LogThread to not panic if stderr can't be wrapped. Instead it will just continue and not log to stderr.

This prevents test errors in CI if there is no tty.