### PR TITLE
Fix panic in drop method of PluginProcess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "git-testament 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "is_executable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "named_type 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -329,6 +330,14 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "is_executable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,6 +989,7 @@ dependencies = [
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79d98ee7dd1d2e796d254807fd86ea7189d07571aeaa74007603e29a79d15217"
+"checksum is_executable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -68,6 +68,7 @@ humantime = "1.2"
 rand = "0.6"
 rand_chacha = "0.1"
 num-complex = "0.2"
+is_executable = "0.1"
 structopt = { version = "0.2", optional = true }
 ansi_term = { version = "0.11", optional = true }
 clap = { version = "2.33", optional = true }

--- a/rust/src/bin/dqcsim/main.rs
+++ b/rust/src/bin/dqcsim/main.rs
@@ -311,6 +311,11 @@ mod tests {
     }
 
     #[test]
+    fn not_executable() {
+        assert!(err!(cli!("../LICENSE", "../LICENSE")).contains("Failed to spawn plugin(s)"));
+    }
+
+    #[test]
     fn loglevel() {
         assert!(cli!("-l", "fatal", FRONTEND, BACKEND).is_ok());
         assert!(cli!("-l", "f", FRONTEND, BACKEND).is_ok());

--- a/rust/src/core/host/simulation.rs
+++ b/rust/src/core/host/simulation.rs
@@ -9,7 +9,7 @@ use crate::{
         protocol::{FrontendRunRequest, PluginToSimulator},
         types::{ArbCmd, ArbData, PluginMetadata},
     },
-    debug, error,
+    debug, error, fatal,
     host::{
         accelerator::Accelerator,
         configuration::Seed,
@@ -147,11 +147,14 @@ impl Simulation {
         }
 
         // Spawn the plugins.
-        let (_, errors): (_, Vec<_>) = pipeline
+        let (_, errors): (_, Vec<Result<()>>) = pipeline
             .iter_mut()
             .map(|plugin| plugin.spawn(logger))
             .partition(Result::is_ok);
         if !errors.is_empty() {
+            for error in errors {
+                fatal!("{}", error.as_ref().unwrap_err());
+            }
             err("Failed to spawn plugin(s)")?
         }
 


### PR DESCRIPTION
Closes #85 

The drop method of a `PluginProcess` assumed the child field to be `Some`. However, in the case of a spawn failure it obviously isn't, causing the `self.child.as_mut()` to panic. There is a check now in the drop method, skipping the child related logic if the process never spawned.
There's also a check now which check is the `PluginProcess` executable path is executable. If not, there's a fatal log message informing the user of this problem.